### PR TITLE
Removed hardcoding of letter_to_index dict

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,21 +14,7 @@ class Colors:
 
 class Test:
     letter_to_index = {
-        'a': 0,
-        'b': 1,
-        'c': 2,
-        'd': 3,
-        'e': 4,
-        'f': 5,
-        'g': 6,
-        'h': 7,
-        'i': 8,
-        'j': 9,
-        'k': 10,
-        'l': 11,
-        'm': 12,
-        'n': 13,
-        'o': 14
+        chr(ascii): ascii - ord('a') for ascii in range(ord('a'), ord('z') + 1)
     }
 
     def __init__(self, file_path):


### PR DESCRIPTION
This should also fill up the dict with keys from `'a'` to `'z'`, not only to `'o'`.

---

Why was this more exciting to do than actually learning for the damned test?